### PR TITLE
🚀 chore/add-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MarkRabey


### PR DESCRIPTION
**Summary:**
Added a new `.github/CODEOWNERS` file with ownership set to `@MarkRabey`.

**Context:**
This file specifies code ownership for the repository and designates MarkRabey as the default owner.

**Notes for Reviewers:**
Please ensure that the ownership assignment is correct and reflects the intended code ownership structure.