### PR TITLE
🚀 feat/pr-mode

### DIFF
--- a/.git-chimprc
+++ b/.git-chimprc
@@ -1,4 +1,5 @@
 {
   "model": "gpt-4o",
-  "tone": "sarcastic"
+  "tone": "sarcastic",
+  "prMode": "draft"
 }

--- a/README.md
+++ b/README.md
@@ -69,26 +69,28 @@ GITHUB_REPO=username/repo
 
 ```json
 {
-  "config": {
-    "tone": "sarcastic",
-    "enforceSemanticPrTitles": true,
-    "model": "gpt-4"
-  }
+  "tone": "sarcastic",
+  "enforceSemanticPrTitles": true,
+  "model": "gpt-4o",
+  "prMode": "draft"
 }
 ```
 
 ### Available Config Options
 
-| Key                       | Type      | Description                                                                     |
-| ------------------------- | --------- | ------------------------------------------------------------------------------- |
-| `enforceSemanticPrTitles` | `boolean` | If `true`, the PR title will follow semantic-release style (e.g., `feat:`).     |
-| `model`                   | `string`  | OpenAI model to use. One of: `gpt-3.5-turbo`, `gpt-4`, `gpt-4o`, `gpt-4o-mini`. |
+| Key                       | Type      | Description                                                                         |
+| ------------------------- | --------- | ----------------------------------------------------------------------------------- |
+| `tone`                    | `string`  | Sets the writing style, e.g., `"corporate-safe"`, `"dry sarcasm"`, `"chaotic evil"` |
+| `model`                   | `string`  | OpenAI model to use. One of: `gpt-3.5-turbo`, `gpt-4`, `gpt-4o`, `gpt-4o-mini`      |
+| `enforceSemanticPrTitles` | `boolean` | If `true`, PR titles follow semantic-release style (e.g., `feat:`)                  |
+| `prMode`                  | `string`  | One of: `open` (default), `draft`, or `display` (just show the PR content)          |
+
 
 ### Command-Line Overrides
 You can also override certain config options via CLI flags (these take precedence over `.git-chimprc`):
 
 ```bash
-git-chimp pr --semantic-title false
+git-chimp pr --tone "inspired by Linus Torvalds" --model gpt-4o --pr-mode draft
 ```
 
 That would skip enforcing semantic PR title style for that invocation, regardless of the `.git-chimprc` setting.
@@ -116,8 +118,13 @@ git-chimp commit
 
 #### Options:
 
-- `-c`, `--custom` – Write a custom commit message instead of using GPT (you absolute control freak)
-- `-m`, `--message` – Non-interactive mode: print GPT's message to stdout and exit. Great for scripting or CI.
+| Flag              | Description                                                              |
+| ----------------- | ------------------------------------------------------------------------ |
+| `--tone <style>`  | Optional writing style for commit messages (e.g., `"corporate-safe"`)    |
+| `--model <model>` | OpenAI model to use (e.g., `gpt-3.5-turbo`, `gpt-4o`)                    |
+| `-c`, `--custom`  | Use your own lovingly typed commit message (you beautiful control freak) |
+| `-m`, `--message` | Print GPT commit messages to stdout and exit (good for CI, scripting)    |
+
 
 ### `pr`
 
@@ -129,7 +136,24 @@ Generates a PR description and opens one on GitHub.
 
 #### Options:
 
-- `-u`, `--update` – Automatically update an existing PR if one already exists for the branch.
+| Flag               | Description                                                            |
+| ------------------ | ---------------------------------------------------------------------- |
+| `--tone <style>`   | Optional writing style for the PR (e.g., `"professional"`, `"snarky"`) |
+| `--model <model>`  | OpenAI model to use for generation                                     |
+| `--pr-mode <mode>` | One of: `open`, `draft`, or `display`                                  |
+| `-u`, `--update`   | Updates an existing PR instead of creating a new one (if it exists)    |
+
+---
+## 💡 Pro Tip
+The config system is merge-friendly. It works like this (highest priority wins):
+
+Command-line flags (e.g., --tone)
+
+.git-chimprc config
+
+Defaults baked into the tool
+
+So yeah—you can go full control freak without ever touching a config file, or commit to the chimp with a persistent setup.
 
 ---
 

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -51,7 +51,8 @@ export async function handleCommitCommand(
       const messages = await generateCommitMessages(
         diff,
         3,
-        config.tone
+        config.tone,
+        config.model
       );
       const first = messages[0] ?? 'chore: update';
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -43,6 +43,10 @@ export function runCLI() {
       '--tone <tone>',
       'Set the tone of the message (e.g. sarcastic, friendly, neutral)'
     )
+    .option(
+      '--model <model>',
+      'OpenAI model to use (gpt-3.5-turbo | gpt-4 | gpt-4o | gpt-4o-mini)'
+    )
     .option('-c, --custom', 'Write a custom commit message')
     .option(
       '-m, --message',
@@ -52,6 +56,10 @@ export function runCLI() {
 
   program
     .command('pr')
+    .option(
+      '--pr-mode <mode>',
+      'Set PR mode: open, draft, or display'
+    )
     .option(
       '--tone <tone>',
       'Set the tone of the message (e.g. sarcastic, friendly, neutral)'

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -5,7 +5,7 @@ import { loadConfig } from '../utils/config.js';
 config();
 
 const chimpConfig = await loadConfig();
-const model = chimpConfig.model ?? 'gpt-3.5-turbo';
+// const model = chimpConfig.model ?? 'gpt-3.5-turbo';
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY || '',
@@ -14,7 +14,8 @@ const openai = new OpenAI({
 export async function generateCommitMessages(
   diff: string,
   count = 3,
-  tone?: string
+  tone?: string,
+  model: string = 'gpt-3.5-turbo'
 ): Promise<string[]> {
   const toneDescription = tone ? ` with a ${tone} tone` : '';
   const prompt = `
@@ -39,7 +40,8 @@ Messages should be short, use present tense, and follow conventional commit styl
 
 export async function generatePullRequestDescription(
   diff: string,
-  tone?: string
+  tone?: string,
+  model: string = 'gpt-3.5-turbo'
 ): Promise<string> {
   const toneDescription = tone ? ` with a ${tone} tone` : '';
   const prompt = `

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 export type ChimpConfig = {
   enforceSemanticPrTitles?: boolean;
   model?: 'gpt-3.5-turbo' | 'gpt-4' | 'gpt-4o' | 'gpt-4o-mini';
+  prMode?: 'open' | 'draft' | 'display';
   tone?:
     | 'neutral'
     | 'friendly'


### PR DESCRIPTION
# Pull Request: A Masterpiece of Configuration Tweaks 🛠️

## Summary
In this stunning display of configuration prowess, we've added the `prMode` option to our `.git-chimprc` cocktail, clearly outshining anything else in existence. Now you can set your Pull Request mode to `open`, `draft`, or just `display` its sheer brilliance for the masses.

## Key Changes
- **Updated `.git-chimprc`**: Because who doesn't love more options? Added `prMode`, nestled right alongside our beloved `tone` and `model` settings like the overachieving siblings they are.
- **README.md** got a facelift: Documentation that even your grandma could follow. We've expanded the table of config options and CLI flags because, really, who doesn't enjoy extended reading material?
- **Command support**: You wanted options, now you've got options. Added CLI hooks for `--model` and `--pr-mode` because who wouldn't want to toggle between life-altering modes on the fly?
- **Semantic PR Titles**: Now we're playing for keeps. Enforce semantic prefixes unless you're feeling wild and want a warning instead. Somebody call the fun police.
- **OpenAI Model Integration**: Setting the model is like choosing an ice cream flavor, except with slightly more existential dread.

## Points of Interest
- We guessed your semantic prefix like a wizard, and we won’t let you forget it. 
- `generatePullRequestDescription` and `generateCommitMessages` now pass their `model` because the AI needs to feel included too.
- CLI command structure was improved because life is all about enhancing the user experience, one tedious detail at a time.

## Pro Tips
- The config system is *merge-friendly*. Yes, we're accommodating like that.
- You can override the default config using command-line flags. Go ahead, be the control freak you aspire to be.

## Context & Notes
This configuration extravaganza is designed to enrich your Git adventures with fully customizable options for tone and model, by popular demand.

### Reviewer's Checklist:
- Check if you agree that adding more options is the pinnacle of modern software development.
- Confirm that the new `prMode` functionality makes you question why it wasn’t there from the start.

Your turn to bask in this marvel of digital engineering. 🎉