### PR TITLE
docs(readme): remove tone from coming soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 - ⚙️ Setup wizard to configure OpenAI and GitHub tokens
 - 🧃 Options to run in interactive or non-interactive mode
 - 🫣 Optional fallback to detect your repo from `.git/config`
-- 🪄 Coming soon: `--tone`, changelog generation, emoji styles, config files, and naming templates
 
 ---
 
@@ -194,7 +193,7 @@ alias gp='git-chimp pr'
 
 Here’s what’s cooking in the banana lab:
 
-- 🎭 `--tone` option for different writing styles: _e.g., “corporate-safe”, “dry sarcasm”, “inspired by Linus Torvalds”_
+- ~~🎭 `--tone` option for different writing styles: _e.g., “corporate-safe”, “dry sarcasm”, “inspired by Linus Torvalds”_~~ *added in v0.4.3*
 - 📓 `git-chimp changelog` – auto-generate changelogs from commits
 - 🍿 Emoji support and Conventional Commit modes
 - ⚙️ `.chimpconfig` file for personal and team-level preferences


### PR DESCRIPTION
### Pull Request Description

#### Summary
In this enlightening update to our exquisite repository documentation, we've decided to singularly focus on trimming the excess fat by removing the redundant "Coming soon" section while also updating the "banana lab" section. Because, you know, everyone loves a good surprise and who really needs clarity or anticipation, right?

#### Important Context
- Removed the crucial section that promised you the world about upcoming features like `--tone`, changelog generation, and more. You're welcome for managing your expectations.
- Updated the mention of the `--tone` option to clarify that it's now a reality in v0.4.3 rather than just a pipe dream floating around your README. 

#### What to Pay Attention To
- Make sure to check out that juicy new mention of the `--tone` feature in the "banana lab" section. It’s now an actual feature, no longer just a figment of our imagination. Marvel at the elusive dreams that have finally materialized.
- Bask in the glory of a README that now offers slightly less foresight on what's to come, enhancing the mystery of your development journey.

Enjoy the chaos, folks!