### PR TITLE
feat: add AI summary generation and changelog group ordering

### DIFF
--- a/.chimprc
+++ b/.chimprc
@@ -4,7 +4,11 @@
     "tone": "sarcastic",
     "prMode": "draft",
     "enforceSemanticPrTitles": true,
-    "enforceConventionalCommits": true
+    "enforceConventionalCommits": true,
+    "changelog": {
+      "useAI": true,
+      "groupOrder": ["feat", "fix", "docs", "chore"]
+    }
   },
   "docChimp": {
     "outputDir": "docs"

--- a/.chimprc
+++ b/.chimprc
@@ -5,5 +5,8 @@
     "prMode": "draft",
     "enforceSemanticPrTitles": true,
     "enforceConventionalCommits": true
+  },
+  "docChimp": {
+    "outputDir": "docs"
   }
 }

--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ alias gp='git-chimp pr'
 
 Here’s what’s cooking in the banana lab:
 
-- ~~🎭 `--tone` option for different writing styles: _e.g., “corporate-safe”, “dry sarcasm”, “inspired by Linus Torvalds”_~~ *added in v0.4.3*
-- 📓 `git-chimp changelog` – auto-generate changelogs from commits
+- ~~🎭 `--tone` option for different writing styles: _e.g., “corporate-safe”, “dry sarcasm”, “inspired by Linus Torvalds”_~~ ✅ *Done*
+- ~~📓 `git-chimp changelog` – auto-generate changelogs from commits~~ ✅ *Done*
 - 🍿 Emoji support and Conventional Commit modes
-- ⚙️ `.chimpconfig` file for personal and team-level preferences
-- 🔀 Branch naming assistant (`git-chimp name`)
+- ⚙️ `.chimprc` file for personal and team-level preferences - currently per-project. Updates will allow for options like `~/.chimprc`
+- 🔀 Branch naming assistant (`git-chimp name` or `git-chimp branch`)
 - 🧪 Dry run support (`--dry-run`)
 
 ---

--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ GITHUB_REPO=username/repo
     "tone": "sarcastic",
     "prMode": "draft",
     "enforceSemanticPrTitles": true,
-    "enforceConventionalCommits": true
+    "enforceConventionalCommits": true,
+    "changelog": {
+      "aiSummary": true,
+      "output": "CHANGELOG.md",
+      "from": "v1.0.0",
+      "to": "HEAD"
+    }
   }
 }
 ```
@@ -90,6 +96,17 @@ GITHUB_REPO=username/repo
 | `enforceConventionalCommits` | `boolean` | If `true`, commit messages follow conventional commit style: `type(scope): description` (e.g., `feat(auth): add login button`)      
 | `enforceSemanticPrTitles` | `boolean` | If `true`, PR titles follow semantic-release style (e.g., `feat:`)                  |
 | `prMode`                  | `string`  | One of: `open` (default), `draft`, or `display` (just show the PR content)          |
+| `changelog`               | `object`  | Options for changelog generation (see below)                                        |
+
+If you include a `changelog` object, it supports the following:
+| `changelog` key | Type      | Description                                                             |
+| --------------- | --------- | ----------------------------------------------------------------------- |
+| `aiSummary`     | `boolean` | If `true`, uses OpenAI to generate a summary section for the changelog  |
+| `output`        | `string`  | File path to write or append changelog content (e.g., `"CHANGELOG.md"`) |
+| `from`          | `string`  | Git tag or commit to start from (e.g., `"v1.0.0"`)                      |
+| `to`            | `string`  | Git ref to end at (defaults to `HEAD` if omitted)                       |
+
+You can override any of these with CLI flags when running `git-chimp changelog`.
 
 
 ### Command-Line Overrides
@@ -150,6 +167,24 @@ Generates a PR description and opens one on GitHub.
 | `--pr-mode <mode>` | One of: `open`, `draft`, or `display`                                  |
 | `--semantic-title` | Enforce semantic PR titles                                             |
 | `-u`, `--update`   | Updates an existing PR instead of creating a new one (if it exists)    |
+
+### `changelog`
+
+```bash
+git-chimp changelog
+```
+
+Generates a changelog from commit history, optionally summarized with AI.
+
+#### Options:
+
+| Flag               | Description                                                                 |
+| ------------------ | --------------------------------------------------------------------------- |
+| `--from <tag>`     | Git tag or commit to start from (defaults to latest tag)                    |
+| `--to <ref>`       | Git ref to end at (defaults to `HEAD`)                                      |
+| `--output <file>`  | Path to a file to append the changelog to                                   |
+| `--ai`             | Use OpenAI to generate a summary section                                    |
+
 
 ---
 ## 💡 Pro Tip

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,12 @@
+# Recent Commits
+
+- docs: update README for `.chimprc` and new flags (33beebe50292e9e9d586ebc0afc4aecb5ffe1f50)
+- chore(release): 0.5.0 [skip ci] (9a0ce358f1ec1982c340d2959377709eeb9b6950)
+- feat: add function to generate semantic PR titles based on git diff (#11) (22494a526e913d7ffdee11280e7893632bb1927e)
+- docs(readme):remove tone from coming soon (#10) (e772ca82c8de4d0ddc7b48da0d1748994d98c3d5)
+- chore(release): 0.4.3 [skip ci] (8d417140e87cf968f5749451ee2f3e5bdecd6e48)
+- fix(scripts): remove duplicate release trigger comment (75fdfe136cc366b3bd3e45b07c1ad0dc63ed4d94)
+- 🚀 feat/pr-mode (#9) (7ddf0794e8ba3e4878d47cd2a5e80d0eab7316ce)
+- chore: update package version and license (055b4ddf6f370721abe42bcada82fee0be75ad0b)
+- chore(release): 0.4.2 [skip ci] (0a9c83090b58c2dacbfd9c91019f806fba777c6e)
+- Merge branch 'main' of github.com:MarkRabey/git-chimp (a46921740141a428d10a796abb03e5870d3746a6)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-chimp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-chimp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^22.0.0",

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -1,0 +1,95 @@
+import { simpleGit } from 'simple-git';
+import chalk from 'chalk';
+import fs from 'fs';
+import type { DefaultLogFields, ListLogLine } from 'simple-git';
+import { loadGitChimpConfig } from '../utils/config.js';
+import { generateChangelogEntries } from '../lib/openai.js'; // New helper
+
+export async function handleChangelog(
+  options: {
+    from?: string;
+    to?: string;
+    output?: string;
+    ai?: boolean;
+  } = {}
+) {
+  const config = await loadGitChimpConfig();
+  const git = simpleGit();
+
+  const from = options.from || (await git.tags()).latest;
+  const to = options.to || 'HEAD';
+
+  if (!from) {
+    console.error(
+      chalk.red(
+        '❌ No tags found to use as a starting point. Use --from manually.'
+      )
+    );
+    process.exit(1);
+  }
+
+  const log = await git.log({ from, to });
+  const commits: (DefaultLogFields & ListLogLine)[] = [...log.all];
+
+  if (commits.length === 0) {
+    console.log(
+      chalk.yellow('⚠️ No commits found between specified tags.')
+    );
+    process.exit(0);
+  }
+
+  const semanticGroups: Record<string, string[]> = {};
+
+  for (const c of commits) {
+    const match = c.message.match(
+      /^(feat|fix|docs|chore|style|refactor|perf|test)(\(.*?\))?: (.+)/
+    );
+    if (match) {
+      const type = match[1];
+      const description = match[3];
+      if (!semanticGroups[type]) semanticGroups[type] = [];
+      semanticGroups[type].push(description);
+    }
+  }
+
+  let output = `## Changelog (${from} → ${to})\n\n`;
+
+  const groupOrder = config?.changelog?.groupOrder || [
+    'feat',
+    'fix',
+    'refactor',
+    'perf',
+    'docs',
+    'test',
+    'chore',
+  ];
+  for (const type of groupOrder) {
+    if (semanticGroups[type]?.length) {
+      output += `### ${type}\n`;
+      for (const desc of semanticGroups[type]) {
+        output += `- ${desc}\n`;
+      }
+      output += '\n';
+    }
+  }
+
+  if (options.ai || config?.changelog?.useAI) {
+    const aiSummary = await generateChangelogEntries(
+      commits,
+      config.tone,
+      config.model
+    );
+    output = `### 🧠 Summary\n${aiSummary}\n\n` + output;
+  }
+
+  if (options.output) {
+    fs.appendFileSync(options.output, output);
+    console.log(
+      chalk.green(`✅ Changelog written to ${options.output}`)
+    );
+  } else {
+    console.log(output);
+  }
+
+  process.exit(0);
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,9 +2,10 @@ import { Command } from 'commander';
 import { handleCommitCommand } from './commit.js';
 import { handlePR } from './pr.js';
 import { handleInit } from './init.js';
+import { handleConfig } from './config.js';
+import { handleChangelog } from './changelog.js';
 // Import JSON using createRequire for NodeNext compatibility
 import { createRequire } from 'node:module';
-import { handleConfig } from './config.js';
 const require = createRequire(import.meta.url);
 const { version } = require('../../package.json');
 
@@ -87,6 +88,21 @@ export function runCLI() {
       'Generate a pull request with GPT based on recent commits'
     )
     .action(handlePR);
+
+  program
+    .command('changelog')
+    .alias('cl')
+    .description(
+      'Generate a changelog based on semantic commit messages'
+    )
+    .option('--from <tag>', 'Start tag or commit')
+    .option('--to <tag>', 'End tag or commit (default: HEAD)')
+    .option(
+      '--output <file>',
+      'Output changelog to file (will append if file exists)'
+    )
+    .option('--ai', 'Use AI to generate a summary')
+    .action(handleChangelog);
 
   program.parse(process.argv);
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -26,7 +26,7 @@ export function runCLI() {
   program
     .command('config')
     .description(
-      'Get/set git-chimp configuration in .git-chimprc (JSON format)'
+      'Get/set git-chimp configuration in .chimprc (JSON format)'
     )
     .option('-l, --list', 'List current config')
     .option('-g, --get <key>', 'Get value by key')

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,4 +1,5 @@
 import { config } from 'dotenv';
+import type { DefaultLogFields, ListLogLine } from 'simple-git';
 import OpenAI from 'openai';
 
 config();
@@ -96,4 +97,21 @@ Include a brief summary of the changes, mention any important context, and highl
     completion.choices[0].message.content?.trim() ||
     'This PR contains general updates and improvements.'
   );
+}
+
+export async function generateChangelogEntries(
+  commits: (DefaultLogFields & ListLogLine)[],
+  tone = 'concise',
+  model = 'gpt-4'
+): Promise<string> {
+  const messages = commits.map((c) => `- ${c.message}`).join('\n');
+
+  const prompt = `You are a release manager. Given these commit messages, summarize the changes and write a professional changelog summary in a ${tone} tone:\n\n${messages}`;
+
+  const response = await openai.chat.completions.create({
+    messages: [{ role: 'user', content: prompt }],
+    model,
+  });
+
+  return response.choices[0].message.content ?? '';
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -15,6 +15,10 @@ export type GitChimpConfig = {
     | 'sarcastic'
     | 'enthusiastic'
     | string;
+  changelog?: {
+    useAI?: boolean;
+    groupOrder?: string[];
+  };
 };
 
 export async function loadGitChimpConfig(): Promise<GitChimpConfig> {


### PR DESCRIPTION
Ah, another round of exciting updates for our Git-chimp tool! This pull request introduces the ability to enforce conventional commits and semantic PR titles. But wait, there's more! Now you can also generate a changelog with the help of OpenAI, provided you specify the starting point, output file, and let the AI work its magic. Don't forget to check out the new documentation in the `docs` folder for an overview of recent commits. So, get ready to be amazed by the power of Git-chimp, where every commit is a masterpiece and every PR a work of art. Enjoy the sarcasm-infused journey ahead! 🚀